### PR TITLE
Hmatrix

### DIFF
--- a/cm/bin/CMakeLists.txt
+++ b/cm/bin/CMakeLists.txt
@@ -1,10 +1,12 @@
 add_executable(cm_reconstruct cm_reconstruct.cc)
 add_executable(cm_simulation cm_simulation.cc)
 add_executable(cm_g4reconstruct cm_g4reconstruct.cc)
+add_executable(cm_hmatrix cm_hmatrix.cc)
 
 target_link_libraries(cm_reconstruct cc6_cm CmdLineArgs)
 target_link_libraries(cm_simulation cc6_cm CmdLineArgs)
 target_link_libraries(cm_g4reconstruct cc6_cm CmdLineArgs)
+target_link_libraries(cm_hmatrix cc6_cm CmdLineArgs)
 
 install(TARGETS cm_reconstruct cm_simulation cm_g4reconstruct
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/cm/bin/cm_g4reconstruct.cc
+++ b/cm/bin/cm_g4reconstruct.cc
@@ -1,11 +1,12 @@
 #include "CLog.hh"
-#include "CMReconstruction.hh"
-#include "G4Reconstruction.hh"
-#include "G4SimulationAdapter.hh"
 
 #include <TStopwatch.h>
 
 #include <CmdLineConfig.hh>
+
+#include "CMReconstruction.hh"
+#include "G4Reconstruction.hh"
+#include "G4SimulationAdapter.hh"
 
 int main(int argc, char** argv) {
   CmdLineOption cmdopt_output("Output", "-o",
@@ -21,7 +22,7 @@ int main(int argc, char** argv) {
 
   spdlog::set_level(spdlog::level::debug);
 
-  const Positional & pargs = CmdLineConfig::GetPositionalArguments();
+  const Positional& pargs = CmdLineConfig::GetPositionalArguments();
   if (pargs.size() < 2) {
     spdlog::error("Not enough arguments, {} are required", 2);
 

--- a/cm/bin/cm_hmatrix.cc
+++ b/cm/bin/cm_hmatrix.cc
@@ -1,31 +1,30 @@
 #include "CLog.hh"
+
 #include <TFile.h>
 #include <TString.h>
+
 #include "CMReconstruction.hh"
 #include "CmdLineConfig.hh"
 
-
-
 int main(int argc, char** argv) {
-	spdlog::set_level(spdlog::level::info);
+  spdlog::set_level(spdlog::level::info);
 
-	CmdLineOption opt_output("Output", "-o",
+  CmdLineOption opt_output("Output", "-o",
                            "Output file (string), default: Hmatrix.root",
                            "Hmatrix.root");
 
-	CmdLineArg cmdarg_input("input", "Input file", CmdLineArg::kString);
+  CmdLineArg cmdarg_input("input", "Input file", CmdLineArg::kString);
 
-	CmdLineConfig::instance()->ReadCmdLine(argc, argv);
+  CmdLineConfig::instance()->ReadCmdLine(argc, argv);
 
-	const Positional& args = CmdLineConfig::GetPositionalArguments();	
-	
-	spdlog::info("Outputfile: {}",opt_output.GetStringValue());
+  const Positional& args = CmdLineConfig::GetPositionalArguments();
 
-	TString inputfile(args.at("input")->GetStringValue()); //INPUT
-    TString outputfile(opt_output.GetStringValue()); //OUTPUT
+  spdlog::info("Outputfile: {}", opt_output.GetStringValue());
 
-	CMReconstruction reconstruction(inputfile);
-	
-	reconstruction.HmatrixToFile(outputfile);
+  TString inputfile(args.at("input")->GetStringValue()); // INPUT
+  TString outputfile(opt_output.GetStringValue());       // OUTPUT
 
+  CMReconstruction reconstruction(inputfile);
+
+  reconstruction.HmatrixToFile(outputfile);
 }

--- a/cm/bin/cm_hmatrix.cc
+++ b/cm/bin/cm_hmatrix.cc
@@ -1,19 +1,37 @@
 #include "CLog.hh"
-
+#include <TFile.h>
+#include <TString.h>
+#include "CMReconstruction.hh"
+#include "CmdLineConfig.hh"
 
 
 
 int main(int argc, char** argv) {
-  spdlog::set_level(spdlog::level::info);
+	spdlog::set_level(spdlog::level::info);
 
-    spdlog::info("Hello, Vitalii!");
-	if (argc != 3) {
-	    spdlog::info(
-	        "type: './cm_reconstruct [INPUTFILENAME] [OUTPUTFILENAME]' to start:\n\n"
-	        "where:\n\n"
-	        "INPUTFILENAME - is an input file from simulations\n\n"
-	        "OUTPUTFILENAME - is an output file for H matrix\n\n");
-	    return 1;
-  	}		
+	CmdLineOption opt_output("Output", "-o",
+                           "Output file (string), default: Hmatrix.root",
+                           "Hmatrix.root");
+
+	CmdLineConfig::instance()->ReadCmdLine(argc, argv);
+	PositionalArgs args = CmdLineOption::GetPositionalArguments();
+
+	spdlog::info("Hello, Vitalii!");
+	if (args.size() != 1 ) {
+		spdlog::info(
+		    "type: './cm_reconstruct [INPUTFILENAME] ' to start:\n\n"
+		    "where:\n\n"
+		    "INPUTFILENAME - is an input file from simulations\n\n");
+		return 1;
+	}		
+
+	spdlog::info("Outputfile: {}",opt_output.GetStringValue());
+
+    TString inputfile(args[0]); //INPUT
+    TString outputfile(opt_output.GetStringValue()); //OUTPUT
+
+	CMReconstruction reconstruction(inputfile);
+	
+	reconstruction.HmatrixToFile(outputfile,1);
 
 }

--- a/cm/bin/cm_hmatrix.cc
+++ b/cm/bin/cm_hmatrix.cc
@@ -1,0 +1,19 @@
+#include "CLog.hh"
+
+
+
+
+int main(int argc, char** argv) {
+  spdlog::set_level(spdlog::level::info);
+
+    spdlog::info("Hello, Vitalii!");
+	if (argc != 3) {
+	    spdlog::info(
+	        "type: './cm_reconstruct [INPUTFILENAME] [OUTPUTFILENAME]' to start:\n\n"
+	        "where:\n\n"
+	        "INPUTFILENAME - is an input file from simulations\n\n"
+	        "OUTPUTFILENAME - is an output file for H matrix\n\n");
+	    return 1;
+  	}		
+
+}

--- a/cm/bin/cm_hmatrix.cc
+++ b/cm/bin/cm_hmatrix.cc
@@ -13,20 +13,15 @@ int main(int argc, char** argv) {
                            "Output file (string), default: Hmatrix.root",
                            "Hmatrix.root");
 
+	CmdLineArg cmdarg_input("input", "Input file", CmdLineArg::kString);
+
 	CmdLineConfig::instance()->ReadCmdLine(argc, argv);
-	PositionalArgs args = CmdLineOption::GetPositionalArguments();
 
-	if (args.size() != 1 ) {
-		spdlog::info(
-		    "type: './cm_reconstruct [INPUTFILENAME] ' to start:\n\n"
-		    "where:\n\n"
-		    "INPUTFILENAME - is an input file from simulations\n\n");
-		return 1;
-	}		
-
+	const Positional& args = CmdLineConfig::GetPositionalArguments();	
+	
 	spdlog::info("Outputfile: {}",opt_output.GetStringValue());
 
-    TString inputfile(args[0]); //INPUT
+	TString inputfile(args.at("input")->GetStringValue()); //INPUT
     TString outputfile(opt_output.GetStringValue()); //OUTPUT
 
 	CMReconstruction reconstruction(inputfile);

--- a/cm/bin/cm_hmatrix.cc
+++ b/cm/bin/cm_hmatrix.cc
@@ -32,6 +32,6 @@ int main(int argc, char** argv) {
 
 	CMReconstruction reconstruction(inputfile);
 	
-	reconstruction.HmatrixToFile(outputfile,1);
+	reconstruction.HmatrixToFile(outputfile,0);
 
 }

--- a/cm/bin/cm_hmatrix.cc
+++ b/cm/bin/cm_hmatrix.cc
@@ -16,7 +16,6 @@ int main(int argc, char** argv) {
 	CmdLineConfig::instance()->ReadCmdLine(argc, argv);
 	PositionalArgs args = CmdLineOption::GetPositionalArguments();
 
-	spdlog::info("Hello, Vitalii!");
 	if (args.size() != 1 ) {
 		spdlog::info(
 		    "type: './cm_reconstruct [INPUTFILENAME] ' to start:\n\n"
@@ -32,6 +31,6 @@ int main(int argc, char** argv) {
 
 	CMReconstruction reconstruction(inputfile);
 	
-	reconstruction.HmatrixToFile(outputfile,0);
+	reconstruction.HmatrixToFile(outputfile);
 
 }

--- a/cm/bin/cm_reconstruct.cc
+++ b/cm/bin/cm_reconstruct.cc
@@ -11,28 +11,21 @@ int main(int argc, char** argv) {
   CmdLineOption opt_hmatrix("Hmatrix", "-hmat",
                            "File with H matrix, default: Calculate","");
 
+
+  CmdLineArg cmdarg_inputfile("input", "Input file", CmdLineArg::kString);
+  CmdLineArg cmdarg_iter("iter", "N iterations", CmdLineArg::kInt);
+
   CmdLineConfig::instance()->ReadCmdLine(argc, argv);
-  PositionalArgs args = CmdLineOption::GetPositionalArguments();
-
-
-  if (args.size() != 2) {
-    spdlog::info(
-        "type: './cm_reconstruct [FILENAME] [ITERATIONS]' to start:\n\n"
-        "where:\n\n"
-        "FILE - is an input file from simulations\n\n"
-        "ITERATIONS - is the numer of iterations to be processed.\n\n"); 
-    return 1;
-  }
+  const Positional& args = CmdLineConfig::GetPositionalArguments();
 
   if(opt_hmatrix.GetStringValue()){ 
     spdlog::info("Hmatrix file: {}",opt_hmatrix.GetStringValue());
   } else {
     spdlog::info("Hmatrix will be calculated");
   }
-  // return 1;
 
-  TString filename(args[0]);
-  Int_t iterations = TString(args[1]).Atoi();
+  TString filename(args.at("input")->GetStringValue());
+  Int_t iterations(args.at("iter")->GetIntValue());
 
   CMReconstruction reconstruction(filename);
   reconstruction.RunReconstruction(iterations);

--- a/cm/bin/cm_reconstruct.cc
+++ b/cm/bin/cm_reconstruct.cc
@@ -21,18 +21,18 @@ int main(int argc, char** argv) {
         "where:\n\n"
         "FILE - is an input file from simulations\n\n"
         "ITERATIONS - is the numer of iterations to be processed.\n\n"); 
-    // return 1;
+    return 1;
   }
 
   if(opt_hmatrix.GetStringValue()){ 
     spdlog::info("Hmatrix file: {}",opt_hmatrix.GetStringValue());
   } else {
-    spdlog::info("No Hmatrix detected");
+    spdlog::info("Hmatrix will be calculated");
   }
-  return 1;
+  // return 1;
 
-  TString filename(argv[1]);
-  Int_t iterations = TString(argv[2]).Atoi();
+  TString filename(args[0]);
+  Int_t iterations = TString(args[1]).Atoi();
 
   CMReconstruction reconstruction(filename);
   reconstruction.RunReconstruction(iterations);

--- a/cm/bin/cm_reconstruct.cc
+++ b/cm/bin/cm_reconstruct.cc
@@ -2,17 +2,34 @@
 #include "CMReconstruction.hh"
 #include "G4SimulationAdapter.hh"
 #include <TStopwatch.h>
+#include "CmdLineConfig.hh"
 
 int main(int argc, char** argv) {
   spdlog::set_level(spdlog::level::info);
-  if (argc != 3) {
+
+
+  CmdLineOption opt_hmatrix("Hmatrix", "-hmat",
+                           "File with H matrix, default: Calculate","");
+
+  CmdLineConfig::instance()->ReadCmdLine(argc, argv);
+  PositionalArgs args = CmdLineOption::GetPositionalArguments();
+
+
+  if (args.size() != 2) {
     spdlog::info(
         "type: './cm_reconstruct [FILENAME] [ITERATIONS]' to start:\n\n"
         "where:\n\n"
         "FILE - is an input file from simulations\n\n"
-        "ITERATIONS - is the numer of iterations to be processed.\n\n");
-    return 1;
+        "ITERATIONS - is the numer of iterations to be processed.\n\n"); 
+    // return 1;
   }
+
+  if(opt_hmatrix.GetStringValue()){ 
+    spdlog::info("Hmatrix file: {}",opt_hmatrix.GetStringValue());
+  } else {
+    spdlog::info("No Hmatrix detected");
+  }
+  return 1;
 
   TString filename(argv[1]);
   Int_t iterations = TString(argv[2]).Atoi();

--- a/cm/bin/cm_reconstruct.cc
+++ b/cm/bin/cm_reconstruct.cc
@@ -1,16 +1,17 @@
 #include "CLog.hh"
+
+#include <TStopwatch.h>
+
+#include "CmdLineConfig.hh"
+
 #include "CMReconstruction.hh"
 #include "G4SimulationAdapter.hh"
-#include <TStopwatch.h>
-#include "CmdLineConfig.hh"
 
 int main(int argc, char** argv) {
   spdlog::set_level(spdlog::level::info);
 
-
   CmdLineOption opt_hmatrix("Hmatrix", "-hmat",
-                           "File with H matrix, default: Calculate","");
-
+                            "File with H matrix, default: Calculate", "");
 
   CmdLineArg cmdarg_inputfile("input", "Input file", CmdLineArg::kString);
   CmdLineArg cmdarg_iter("iter", "N iterations", CmdLineArg::kInt);
@@ -18,8 +19,8 @@ int main(int argc, char** argv) {
   CmdLineConfig::instance()->ReadCmdLine(argc, argv);
   const Positional& args = CmdLineConfig::GetPositionalArguments();
 
-  if(opt_hmatrix.GetStringValue()){ 
-    spdlog::info("Hmatrix file: {}",opt_hmatrix.GetStringValue());
+  if (opt_hmatrix.GetStringValue()) {
+    spdlog::info("Hmatrix file: {}", opt_hmatrix.GetStringValue());
   } else {
     spdlog::info("Hmatrix will be calculated");
   }

--- a/cm/bin/cm_simulation.cc
+++ b/cm/bin/cm_simulation.cc
@@ -1,11 +1,14 @@
 #include "CLog.hh"
-#include "CMSimulation.hh"
+#include <iostream>
+
+#include <TSystem.h>
+
 #include "CmdLineConfig.hh"
+
 #include "Sources/MultiPointSource.hh"
 #include "Sources/PlanarSource.hh"
 #include "Sources/PointSource.hh"
-#include <TSystem.h>
-#include <iostream>
+#include "CMSimulation.hh"
 
 int main(int argc, char** argv) {
 
@@ -32,13 +35,14 @@ int main(int argc, char** argv) {
 
   CmdLineConfig::instance()->ReadCmdLine(argc, argv);
 
-  const Positional & args = CmdLineConfig::GetPositionalArguments();
+  const Positional& args = CmdLineConfig::GetPositionalArguments();
 
   spdlog::set_level(spdlog::level::info);
   TString path =
       TString(gSystem->Getenv("CC6DIR")) + "/share/ComptonCamera6/masks/";
 
-  TString fullname = path + "hMURA" + args.at("mask")->GetStringValue() + ".root";
+  TString fullname =
+      path + "hMURA" + args.at("mask")->GetStringValue() + ".root";
   TFile* maskfile = new TFile(fullname, "READ");
   if (maskfile == nullptr) {
     spdlog::error("File with mask: {} does not exist, exit...",

--- a/cm/bin/cm_simulation.cc
+++ b/cm/bin/cm_simulation.cc
@@ -38,6 +38,7 @@ int main(int argc, char** argv) {
   spdlog::set_level(spdlog::level::info);
   TString path =
       TString(gSystem->Getenv("CC6DIR")) + "/share/ComptonCamera6/masks/";
+      // TString(gSystem->Getenv("CC6DIR"));
   TString fullname = path + "hMURA" + args[0] + ".root";
   TFile* maskfile = new TFile(fullname, "READ");
   if (maskfile == nullptr) {

--- a/cm/bin/cm_simulation.cc
+++ b/cm/bin/cm_simulation.cc
@@ -22,10 +22,10 @@ int main(int argc, char** argv) {
                               "Planar-type source, default: NO");
   CmdLineOption opt_detplane_dim(
       "Plane", "-detplane",
-      "Detector plane, 6 values required, default: 0:0:1:600:300:300", 0, 0);
+      "Detector plane, 6 values required, default: 1:0:0:600:300:300", 0, 0);
   CmdLineOption opt_maskplane_dim(
       "Mask", "-maskplane",
-      "Mask plane, 6 values required, default: 0:0:1:500:300:300", 0, 0);
+      "Mask plane, 6 values required, default: 1:0:0:500:300:300", 0, 0);
 
   CmdLineConfig::instance()->ReadCmdLine(argc, argv);
 

--- a/cm/bin/cm_simulation.cc
+++ b/cm/bin/cm_simulation.cc
@@ -22,10 +22,10 @@ int main(int argc, char** argv) {
                               "Planar-type source, default: NO");
   CmdLineOption opt_detplane_dim(
       "Plane", "-detplane",
-      "Detector plane, 6 values required, default: 1:0:0:600:300:300", 0, 0);
+      "Detector plane, 6 values required, default: 0:0:1:600:300:300", 0, 0);
   CmdLineOption opt_maskplane_dim(
       "Mask", "-maskplane",
-      "Mask plane, 6 values required, default: 1:0:0:500:300:300", 0, 0);
+      "Mask plane, 6 values required, default: 0:0:1:500:300:300", 0, 0);
 
   CmdLineConfig::instance()->ReadCmdLine(argc, argv);
 

--- a/cm/lib/CMReconstruction.cc
+++ b/cm/lib/CMReconstruction.cc
@@ -16,7 +16,8 @@ using SiFi::tools::vectorizeMatrix;
 CMReconstruction::~CMReconstruction() = default;
 
 CMReconstruction::CMReconstruction(TString simulationFile) {
-  log->info("Load simulation results from file");
+  // log->info("Load simulation results from file");
+  log->info("Load simulation results from file {}" , simulationFile);
   TFile file(simulationFile, "READ");
   file.Print();
 
@@ -260,4 +261,34 @@ void CMReconstruction::Write(TString filename) const {
 
   file.Close();
   log->debug("end CMReconstruction::Write({})", filename.Data());
+}
+
+
+
+//TODO: remove test and second argument
+void CMReconstruction::HmatrixToFile(TString filename, Int_t t) {
+  if (t == 0) {
+    TFile file(filename, "RECREATE");
+    file.cd();
+
+    log->info("FILL HMATRIX");
+    FillHMatrix();
+    log->info("WRITE");
+    fMatrixH.Write("matrixH");
+    fMask.Write("mask");
+    fDetPlane.Write("detector");
+
+    file.Close();
+  } else {
+    log->info("TEST");
+    
+    TFile file(filename, "READ");
+    file.cd();
+    fMatrixH.Read("matrixH");
+    log->info("Fmask A = {}, B = {}, C = {}, D = {},DimY = {}, DimZ = {}", fMask.GetA(), fMask.GetB(),
+                         fMask.GetC(), fMask.GetD(), fMask.GetDimY(), fMask.GetDimZ());
+    log->info("Fdet A = {}, B = {}, C = {}, D = {},DimY = {}, DimZ = {}", fDetPlane.GetA(), fDetPlane.GetB(),
+                         fDetPlane.GetC(), fDetPlane.GetD(), fDetPlane.GetDimY(), fDetPlane.GetDimZ());
+    file.Close();
+  }
 }

--- a/cm/lib/CMReconstruction.cc
+++ b/cm/lib/CMReconstruction.cc
@@ -58,6 +58,8 @@ CMReconstruction::CMReconstruction(TString simulationFile) {
 
 void CMReconstruction::FillHMatrix() {
   log->info("CMReconstruction::FillHMatrix");
+  // log->info("HI");
+  log->info("ObjBins = {} Imgbins = {}", fObjectCoords.NBins(),fImageCoords.NBins());
 
   int nIterations = 10000;
   for (int objBin = 0; objBin < fObjectCoords.NBins(); objBin++) {
@@ -73,7 +75,7 @@ void CMReconstruction::FillHMatrix() {
       PointSource src(TVector3(0, y, x), 1);
       CMSimulation sim(&src, &fMask, &fDetPlane);
       sim.SetLogLevel(spdlog::level::warn);
-      sim.RunSimulation(nIterations);
+      // sim.RunSimulation(nIterations);
       auto imgVec = vectorizeMatrix(convertHistogramToMatrix(sim.GetImage()));
 
       for (int imgBin = 0; imgBin < fImageCoords.NBins(); imgBin++) {
@@ -146,16 +148,30 @@ void CMReconstruction::RunReconstruction(Int_t nIterations) {
     throw "too many iterations";
   }
 
-  FillHMatrix();
+  // FillHMatrix();
 
-  // log->info("CMReconstruction::Write HMATRIX");
-  // TString filename("Hmatrix.root")
+  log->info("Changed");
+  TString filename("Hmatrix.root");
+  log->info("CMReconstruction::RunReconstruction({})", filename);
   // TFile file(filename, "RECREATE");
+  // TFile file(filename, "UPDATE");
   // file.cd();
   // fMatrixH.Write("matrixH");
-  // break;
 
+  // log->info("CMReconstruction::READ HMATRIX");
+  // TString filename("Hmatrix.root");
+  TFile file(filename);
+  file.cd();
+  // fMatrixH.Read("matrixH");
+  log->info("Fmask A = {}, B = {}, C = {}, D = {},DimY = {}, DimZ = {}", fMask.GetA(), fMask.GetB(),
+                         fMask.GetC(), fMask.GetD(), fMask.GetDimY(), fMask.GetDimZ());
+  log->info("Fdet A = {}, B = {}, C = {}, D = {},DimY = {}, DimZ = {}", fDetPlane.GetA(), fDetPlane.GetB(),
+                         fDetPlane.GetC(), fDetPlane.GetD(), fDetPlane.GetDimY(), fDetPlane.GetDimZ());
+  // fMask.Write("mask");
+  // fDetPlane.Write("detector");
+  // return;
 
+ 
 
   CalculateS();
 

--- a/cm/lib/CMReconstruction.cc
+++ b/cm/lib/CMReconstruction.cc
@@ -147,6 +147,16 @@ void CMReconstruction::RunReconstruction(Int_t nIterations) {
   }
 
   FillHMatrix();
+
+  // log->info("CMReconstruction::Write HMATRIX");
+  // TString filename("Hmatrix.root")
+  // TFile file(filename, "RECREATE");
+  // file.cd();
+  // fMatrixH.Write("matrixH");
+  // break;
+
+
+
   CalculateS();
 
   fRecoObject.push_back(TMatrixT<Double_t>(fObjectCoords.NBins(), 1));

--- a/cm/lib/CMReconstruction.cc
+++ b/cm/lib/CMReconstruction.cc
@@ -176,7 +176,7 @@ void CMReconstruction::RunReconstruction(Int_t nIterations) {
     Double_t da2 = fDetPlane.GetA(), db2 = fDetPlane.GetB(), dc2 = fDetPlane.GetC();
     Double_t dd2 = fDetPlane.GetD(), dY2 = fDetPlane.GetDimY(), dZ2 = fDetPlane.GetDimZ();
 
-
+    //TODO: separate conditions in order to recognize reason of error
     if (fMaskCheckBins != fMaskBins || ma1 != ma2 || mb1 != mb2 || mc1 != mc2 || md1 != md2 || mY1 != mY2 || mZ1 != mZ2){
       log->error("Inconsistent parameters of H matrix and input data");
       log->info("Fmask HFile: \n"
@@ -191,7 +191,7 @@ void CMReconstruction::RunReconstruction(Int_t nIterations) {
       log->info("Fdet InputDataFile: \n"
                 " A = {}, B = {}, C = {}, D = {}, DimY = {}, DimZ = {} \n\n",
                   da2, db2, dc2, dd2, dY2, dZ2);                        
-      throw;
+      exit(EXIT_FAILURE);//exit(number = 'error code')
     }
 
   } else {

--- a/cm/lib/CMReconstruction.cc
+++ b/cm/lib/CMReconstruction.cc
@@ -160,7 +160,9 @@ void CMReconstruction::RunReconstruction(Int_t nIterations) {
     fMatrixHPrime.Transpose(fMatrixH);
     Mask fMaskCheck = *static_cast<Mask*>(hfile.Get("mask"));
     DetPlane fDetPlaneCheck = *static_cast<DetPlane*>(hfile.Get("detector"));
-
+    
+    // log->info("Mask Name: {}",H2Coords(fMaskCheck).NBins());
+//TODO: check mask order
     Double_t ma1 = fMaskCheck.GetA(), mb1 = fMaskCheck.GetB(), mc1 = fMaskCheck.GetC();
     Double_t md1 = fMaskCheck.GetD(), mY1 = fMaskCheck.GetDimY(), mZ1 = fMaskCheck.GetDimZ();
     Double_t da1 = fDetPlaneCheck.GetA(), db1 = fDetPlaneCheck.GetB(), dc1 = fDetPlaneCheck.GetC();
@@ -182,10 +184,10 @@ void CMReconstruction::RunReconstruction(Int_t nIterations) {
                   da1, db1, dc1, dd1, dY1, dZ1);
       log->info("Fmask InputDataFile: \n" 
                 " A = {}, B = {}, C = {}, D = {}, DimY = {}, DimZ = {} \n\n", 
-                  ma1, mb1, mc1, md1, mY1, mZ1);
+                  ma2, mb2, mc2, md2, mY2, mZ2);
       log->info("Fdet InputDataFile: \n"
                 " A = {}, B = {}, C = {}, D = {}, DimY = {}, DimZ = {} \n\n",
-                  da1, db1, dc1, dd1, dY1, dZ1);                        
+                  da2, db2, dc2, dd2, dY2, dZ2);                        
       throw;
     }
 

--- a/cm/lib/CMReconstruction.cc
+++ b/cm/lib/CMReconstruction.cc
@@ -1,13 +1,16 @@
-#include "CMReconstruction.hh"
 #include "CLog.hh"
-#include "CMSimulation.hh"
-#include "DataStructConvert.hh"
-#include "Sources/PointSource.hh"
+
 #include <TCanvas.h>
 #include <TF2.h>
 #include <TMath.h>
 #include <TRandom.h>
+
 #include "CmdLineConfig.hh"
+
+#include "CMReconstruction.hh"
+#include "CMSimulation.hh"
+#include "DataStructConvert.hh"
+#include "Sources/PointSource.hh"
 
 using SiFi::tools::convertHistogramToMatrix;
 using SiFi::tools::convertMatrixToHistogram;
@@ -17,8 +20,6 @@ using SiFi::tools::vectorizeMatrix;
 CMReconstruction::~CMReconstruction() = default;
 
 CMReconstruction::CMReconstruction(TString simulationFile) {
-  // log->info("Load simulation results from file");
-  log->info("Load simulation results from file {}" , simulationFile);
   TFile file(simulationFile, "READ");
   file.Print();
 
@@ -147,10 +148,9 @@ void CMReconstruction::RunReconstruction(Int_t nIterations) {
     throw "too many iterations";
   }
 
-
-  if(CmdLineOption::GetStringValue("Hmatrix")){ 
+  if (CmdLineOption::GetStringValue("Hmatrix")) {
     TString hfilename(CmdLineOption::GetStringValue("Hmatrix"));
-    log->info("Hmatrix file: {}",hfilename);
+    log->info("Hmatrix file: {}", hfilename);
     TFile hfile(hfilename);
     hfile.cd();
 
@@ -163,42 +163,66 @@ void CMReconstruction::RunReconstruction(Int_t nIterations) {
     H2Coords fMaskCoords(fMask.GetPattern());
     Int_t fMaskCheckBins = fMaskCheckCoords.NBins();
     Int_t fMaskBins = fMaskCoords.NBins();
-    log->info("Mask1 bins: {}",fMaskCheckCoords.NBins());
-    log->info("Mask2 bins: {}",fMaskCoords.NBins());
+    log->info("Mask1 bins: {}", fMaskCheckCoords.NBins());
+    log->info("Mask2 bins: {}", fMaskCoords.NBins());
 
-    Double_t ma1 = fMaskCheck.GetA(), mb1 = fMaskCheck.GetB(), mc1 = fMaskCheck.GetC();
-    Double_t md1 = fMaskCheck.GetD(), mY1 = fMaskCheck.GetDimY(), mZ1 = fMaskCheck.GetDimZ();
-    Double_t da1 = fDetPlaneCheck.GetA(), db1 = fDetPlaneCheck.GetB(), dc1 = fDetPlaneCheck.GetC();
-    Double_t dd1 = fDetPlaneCheck.GetD(), dY1 = fDetPlaneCheck.GetDimY(), dZ1 = fDetPlaneCheck.GetDimZ();
+    Double_t ma1 = fMaskCheck.GetA(), mb1 = fMaskCheck.GetB(),
+             mc1 = fMaskCheck.GetC();
+    Double_t md1 = fMaskCheck.GetD(), mY1 = fMaskCheck.GetDimY(),
+             mZ1 = fMaskCheck.GetDimZ();
+    Double_t da1 = fDetPlaneCheck.GetA(), db1 = fDetPlaneCheck.GetB(),
+             dc1 = fDetPlaneCheck.GetC();
+    Double_t dd1 = fDetPlaneCheck.GetD(), dY1 = fDetPlaneCheck.GetDimY(),
+             dZ1 = fDetPlaneCheck.GetDimZ();
 
     Double_t ma2 = fMask.GetA(), mb2 = fMask.GetB(), mc2 = fMask.GetC();
     Double_t md2 = fMask.GetD(), mY2 = fMask.GetDimY(), mZ2 = fMask.GetDimZ();
-    Double_t da2 = fDetPlane.GetA(), db2 = fDetPlane.GetB(), dc2 = fDetPlane.GetC();
-    Double_t dd2 = fDetPlane.GetD(), dY2 = fDetPlane.GetDimY(), dZ2 = fDetPlane.GetDimZ();
+    Double_t da2 = fDetPlane.GetA(), db2 = fDetPlane.GetB(),
+             dc2 = fDetPlane.GetC();
+    Double_t dd2 = fDetPlane.GetD(), dY2 = fDetPlane.GetDimY(),
+             dZ2 = fDetPlane.GetDimZ();
 
-    //TODO: separate conditions in order to recognize reason of error
-    if (fMaskCheckBins != fMaskBins || ma1 != ma2 || mb1 != mb2 || mc1 != mc2 || md1 != md2 || mY1 != mY2 || mZ1 != mZ2){
+    if (fMaskCheckBins != fMaskBins) {
       log->error("Inconsistent parameters of H matrix and input data");
-      log->info("Fmask HFile: \n"
-                " Nbins = {}, A = {}, B = {}, C = {}, D = {}, DimY = {}, DimZ = {} \n\n", 
-                  fMaskCheckBins, ma1, mb1, mc1, md1, mY1, mZ1);
-      log->info("Fdet HFile: \n"
-                "A = {}, B = {}, C = {}, D = {}, DimY = {}, DimZ = {} \n\n", 
-                  da1, db1, dc1, dd1, dY1, dZ1);
-      log->info("Fmask InputDataFile: \n" 
-                "NBins = {},  A = {}, B = {}, C = {}, D = {}, DimY = {}, DimZ = {} \n\n", 
-                  fMaskBins, ma2, mb2, mc2, md2, mY2, mZ2);
-      log->info("Fdet InputDataFile: \n"
-                " A = {}, B = {}, C = {}, D = {}, DimY = {}, DimZ = {} \n\n",
-                  da2, db2, dc2, dd2, dY2, dZ2);                        
-      exit(EXIT_FAILURE);//exit(number = 'error code')
+      log->info("Fmask HFile Nbins = {}", fMaskCheckBins);
+      log->info("Fmask InputDataFile Nbins = {}", fMaskBins);
+      exit(EXIT_FAILURE);
+    } else if (ma1 != ma2) {
+      log->error("Inconsistent parameters of H matrix and input data");
+      log->info("Fmask HFile A = {}", ma1);
+      log->info("Fmask InputDataFile A = {}", ma2);
+      exit(EXIT_FAILURE);
+    } else if (mb1 != mb2) {
+      log->error("Inconsistent parameters of H matrix and input data");
+      log->info("Fmask HFile B = {}", mb1);
+      log->info("Fmask InputDataFile B = {}", mb2);
+      exit(EXIT_FAILURE);
+    } else if (mc1 != mc2) {
+      log->error("Inconsistent parameters of H matrix and input data");
+      log->info("Fmask HFile C = {}", mc1);
+      log->info("Fmask InputDataFile C = {}", mc2);
+      exit(EXIT_FAILURE);
+    } else if (md1 != md2) {
+      log->error("Inconsistent parameters of H matrix and input data");
+      log->info("Fmask HFile D = {}", md1);
+      log->info("Fmask InputDataFile D = {}", md2);
+      exit(EXIT_FAILURE);
+    } else if (mY1 != mY2) {
+      log->error("Inconsistent parameters of H matrix and input data");
+      log->info("Fmask HFile DimY = {}", mY1);
+      log->info("Fmask InputDataFile DimY = {}", mY2);
+      exit(EXIT_FAILURE);
+    } else if (mZ1 != mZ2) {
+      log->error("Inconsistent parameters of H matrix and input data");
+      log->info("Fmask HFile DimZ = {}", mZ1);
+      log->info("Fmask InputDataFile DimZ = {}", mZ2);
+      exit(EXIT_FAILURE);
     }
 
   } else {
     log->info("Hmatrix will be calculated");
     FillHMatrix();
   }
-  // return;
 
   CalculateS();
 
@@ -289,18 +313,17 @@ void CMReconstruction::Write(TString filename) const {
   log->debug("end CMReconstruction::Write({})", filename.Data());
 }
 
+void CMReconstruction::HmatrixToFile(const TString& filename) {
+  TFile file(filename, "RECREATE");
+  file.cd();
 
-void CMReconstruction::HmatrixToFile(TString filename) {
-    TFile file(filename, "RECREATE");
-    file.cd();
+  log->info("FILL Hmatrix");
+  FillHMatrix();
 
-    log->info("FILL Hmatrix");
-    FillHMatrix();
+  log->info("WRITE Hmatrix");
+  fMatrixH.Write("matrixH");
+  fMask.Write("mask");
+  fDetPlane.Write("detector");
 
-    log->info("WRITE Hmatrix");
-    fMatrixH.Write("matrixH");
-    fMask.Write("mask");
-    fDetPlane.Write("detector");
-
-    file.Close();
+  file.Close();
 }

--- a/cm/lib/CMReconstruction.hh
+++ b/cm/lib/CMReconstruction.hh
@@ -43,7 +43,7 @@ public:
   void Write(TString filename) const;
 
   /** Calculate H matrix and save it in file */
-  void HmatrixToFile(TString filename);
+  void HmatrixToFile(const TString& filename);
 
 private:
   /** calulate probability matrix */

--- a/cm/lib/CMReconstruction.hh
+++ b/cm/lib/CMReconstruction.hh
@@ -43,7 +43,7 @@ public:
   void Write(TString filename) const;
 
   /** Calculate H matrix and save it in file */
-  void HmatrixToFile(TString filename, Int_t t);
+  void HmatrixToFile(TString filename);
 
 private:
   /** calulate probability matrix */

--- a/cm/lib/CMReconstruction.hh
+++ b/cm/lib/CMReconstruction.hh
@@ -42,6 +42,9 @@ public:
   /** Save to file */
   void Write(TString filename) const;
 
+  /** Calculate H matrix and save it in file */
+  void HmatrixToFile(TString filename, Int_t t);
+
 private:
   /** calulate probability matrix */
   void FillHMatrix();

--- a/data/sources/Multipoint.mac
+++ b/data/sources/Multipoint.mac
@@ -4,7 +4,7 @@
 /gps/source/intensity 1
 /gps/particle gamma
 /gps/pos/type Point
-/gps/pos/centre 0 0 0 cm
+/gps/pos/centre 0 10 10 cm
 /gps/ang/type iso
 # Direction of the gps is along -z axis
 # Minimum angle around the -z axis - so open for 180 - x 

--- a/tests/test_runner.cpp
+++ b/tests/test_runner.cpp
@@ -1,61 +1,55 @@
-#define CPPUNIT_HAVE_NAMESPACES  1
+#define CPPUNIT_HAVE_NAMESPACES 1
 
-#include <cppunit/extensions/TestFactoryRegistry.h>
-#include <cppunit/ui/text/TestRunner.h>
 #include <cppunit/CompilerOutputter.h>
 #include <cppunit/TestResult.h>
 #include <cppunit/TestResultCollector.h>
 #include <cppunit/TextTestProgressListener.h>
+#include <cppunit/extensions/TestFactoryRegistry.h>
+#include <cppunit/ui/text/TestRunner.h>
 
-#include <stdexcept>
 #include <iostream>
+#include <stdexcept>
 
 using namespace CppUnit;
 using namespace std;
 
-int main (int argc, char ** argv)
-{
-	std::string testPath = (argc > 1) ? std::string(argv[1]) : "";
+int main(int argc, char** argv) {
+  std::string testPath = (argc > 1) ? std::string(argv[1]) : "";
 
-	// Create the event manager and test controller
-	CppUnit::TestResult controller;
+  // Create the event manager and test controller
+  CppUnit::TestResult controller;
 
-	// Add a listener that colllects test result
-	CppUnit::TestResultCollector result;
-	controller.addListener( &result );        
+  // Add a listener that colllects test result
+  CppUnit::TestResultCollector result;
+  controller.addListener(&result);
 
-	// Add a listener that print dots as test run.
-	CppUnit::TextTestProgressListener progress;
-	controller.addListener( &progress );      
+  // Add a listener that print dots as test run.
+  CppUnit::TextTestProgressListener progress;
+  controller.addListener(&progress);
 
-	TestRunner runner;
-	TestFactoryRegistry & registry = TestFactoryRegistry::getRegistry();
+  TestRunner runner;
+  TestFactoryRegistry& registry = TestFactoryRegistry::getRegistry();
 
-	// run all tests if none specified on command line 
-	Test * test_to_run = registry.makeTest();
-	if (argc > 1)
-		test_to_run = test_to_run->findTest(argv[1]);
+  // run all tests if none specified on command line
+  Test* test_to_run = registry.makeTest();
+  if (argc > 1) test_to_run = test_to_run->findTest(argv[1]);
 
-	runner.addTest( test_to_run );
+  runner.addTest(test_to_run);
 
-	try
-	{
-        std::cout << "Running tests " <<  testPath << endl;
-        runner.run( controller, testPath );
+  try {
+    std::cout << "Running tests " << testPath << endl;
+    runner.run(controller, testPath);
 
-        std::cerr << std::endl;
+    std::cerr << std::endl;
 
-		// Print test in a compiler compatible format.
-		CppUnit::CompilerOutputter outputter( &result, std::cerr );
-		outputter.write();                      
-	}
-	catch ( std::invalid_argument &e )  // Test path not resolved
-	{
-		std::cerr  <<  std::endl  
-								<<  "ERROR: "  <<  e.what()
-								<< std::endl;
-		return 0;
-	}
+    // Print test in a compiler compatible format.
+    CppUnit::CompilerOutputter outputter(&result, std::cerr);
+    outputter.write();
+  } catch (std::invalid_argument& e) // Test path not resolved
+  {
+    std::cerr << std::endl << "ERROR: " << e.what() << std::endl;
+    return 0;
+  }
 
-	return result.wasSuccessful() ? 0 : 1;
+  return result.wasSuccessful() ? 0 : 1;
 }

--- a/tools/lib/DataStructConvert.cc
+++ b/tools/lib/DataStructConvert.cc
@@ -10,7 +10,8 @@ TMatrixT<Double_t> convertHistogramToMatrix(TH2F* hist) {
 
   for (int binX = 1; binX <= nBinsX; binX++) {
     for (int binY = 1; binY <= nBinsY; binY++) {
-      matrix(nBinsY - binY, binX - 1) = hist->GetBinContent(binX, binY);
+      // matrix(nBinsY - binY, binX - 1) = hist->GetBinContent(binX, binY);
+      matrix(binY - 1, binX - 1) = hist->GetBinContent(binX, binY);
     }
   }
   return matrix;
@@ -27,7 +28,8 @@ TH2F convertMatrixToHistogram(const char* name, const char* title,
 
   for (int binX = 1; binX <= nBinsX; binX++) {
     for (int binY = 1; binY <= nBinsY; binY++) {
-      hist.SetBinContent(binX, binY, matrix(nBinsY - binY, binX - 1));
+      // hist.SetBinContent(binX, binY, matrix(nBinsY - binY, binX - 1));
+      hist.SetBinContent(binX, binY, matrix(binY - 1, binX - 1));
     }
   }
 

--- a/tools/lib/DataStructConvert.cc
+++ b/tools/lib/DataStructConvert.cc
@@ -10,7 +10,6 @@ TMatrixT<Double_t> convertHistogramToMatrix(TH2F* hist) {
 
   for (int binX = 1; binX <= nBinsX; binX++) {
     for (int binY = 1; binY <= nBinsY; binY++) {
-      // matrix(nBinsY - binY, binX - 1) = hist->GetBinContent(binX, binY);
       matrix(binY - 1, binX - 1) = hist->GetBinContent(binX, binY);
     }
   }
@@ -28,7 +27,6 @@ TH2F convertMatrixToHistogram(const char* name, const char* title,
 
   for (int binX = 1; binX <= nBinsX; binX++) {
     for (int binY = 1; binY <= nBinsY; binY++) {
-      // hist.SetBinContent(binX, binY, matrix(nBinsY - binY, binX - 1));
       hist.SetBinContent(binX, binY, matrix(binY - 1, binX - 1));
     }
   }

--- a/tools/lib/DataStructConvert.hh
+++ b/tools/lib/DataStructConvert.hh
@@ -35,7 +35,8 @@ template <typename T> TMatrixT<T> vectorizeMatrix(const TMatrixT<T>& mat2D) {
 
   for (int row = 0; row < nRows; row++) {
     for (int col = 0; col < nCols; col++) {
-      matVec(col * nRows + row, 0) = mat2D(row, col);
+      // matVec(col * nRows + row, 0) = mat2D(row, col);
+      matVec(row * nCols + col, 0) = mat2D(row, col);
     }
   }
 
@@ -61,7 +62,8 @@ TMatrixT<T> unvectorizeMatrix(const TMatrixT<T>& matVec, Int_t nRows,
 
   for (int row = 0; row < nRows; row++) {
     for (int col = 0; col < nCols; col++) {
-      mat2D(row, col) = matVec(col * nRows + row, 0);
+      // mat2D(row, col) = matVec(col * nRows + row, 0);
+      mat2D(row, col) = matVec(row * nCols + col, 0);
     }
   }
 

--- a/tools/lib/DataStructConvert.hh
+++ b/tools/lib/DataStructConvert.hh
@@ -35,7 +35,6 @@ template <typename T> TMatrixT<T> vectorizeMatrix(const TMatrixT<T>& mat2D) {
 
   for (int row = 0; row < nRows; row++) {
     for (int col = 0; col < nCols; col++) {
-      // matVec(col * nRows + row, 0) = mat2D(row, col);
       matVec(row * nCols + col, 0) = mat2D(row, col);
     }
   }
@@ -62,7 +61,6 @@ TMatrixT<T> unvectorizeMatrix(const TMatrixT<T>& matVec, Int_t nRows,
 
   for (int row = 0; row < nRows; row++) {
     for (int col = 0; col < nCols; col++) {
-      // mat2D(row, col) = matVec(col * nRows + row, 0);
       mat2D(row, col) = matVec(row * nCols + col, 0);
     }
   }


### PR DESCRIPTION
There is a new executable file ```cm/bin/cm_hmarix.cc``` using which it is possible to create '.root' file containing Hmatrix. This one can be used for further reconstructions. The possibility of using this file in ```cm/bin/cm_reconstruction.cc``` is implemented with ```-hmat``` option.
Problem with rotation of reconstruction results is solved in ```tools/lib/DataStructConvert*``` 